### PR TITLE
remove Documenter compat

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
-[compat]
-Documenter = "~0.23"


### PR DESCRIPTION
0.23 is too old that doesn't support GHA deployment.